### PR TITLE
add execute-on-text.js

### DIFF
--- a/execute-on-text.js
+++ b/execute-on-text.js
@@ -1,0 +1,17 @@
+var CLIEngine = require('eslint').CLIEngine
+var eslint = new CLIEngine({
+  env: {},
+  fix: true,
+  globals: [],
+  parser: '',
+  parserOptions: {},
+  plugins: ['node'],
+  root: true,
+  rules: {
+    'node/shebang': 'error',
+  },
+  useEslintrc: false,
+})
+
+var result = eslint.executeOnText('#!/usr/bin/env node\nconsole.log("Hello, world!");')
+console.log(result)


### PR DESCRIPTION
If you run `node execute-on-text.js` you'll see that ESLint is stripping the shebang when autofixing. So this appears to be an ESLint bug. Maybe you could report this to them. Sorry!